### PR TITLE
Fix problem with multiple <title> tags

### DIFF
--- a/lib/notaru/plugins/title.rb
+++ b/lib/notaru/plugins/title.rb
@@ -113,7 +113,7 @@ module Notaru
           return false
         end
 
-        Nokogiri::HTML(html).css('title').text
+        Nokogiri::HTML(html).at_css('head title').text
       end
 
       # @param url [Addressable::URI]


### PR DESCRIPTION
Only grab first occurrence of <title>, and limit it to those inside the <head> section.

Should fix issue with multiple titles being concatenated in for instance http://www.vox.com/2016/5/18/11647970/wireless-charging